### PR TITLE
Fix typo for border-bottom declaration on "Sticky header" example

### DIFF
--- a/client/patterns/sticky-header/Details.tsx
+++ b/client/patterns/sticky-header/Details.tsx
@@ -18,7 +18,7 @@ const Details: React.FC<{}> = () => {
                             <div
                                 style={{
                                     backgroundColor: '#FFF',
-                                    borderBottom: '1ox solid rgba(0, 0, 0, 0.3)',
+                                    borderBottom: '1px solid rgba(0, 0, 0, 0.3)',
                                     padding: '16px',
                                     position: 'sticky',
                                     top: 0,


### PR DESCRIPTION
This fixes the typo that prevented the border bottom from showing in "Sticky header" example.