### PR TITLE
Sidebar pattern update

### DIFF
--- a/client/patterns/sidebar/Details.tsx
+++ b/client/patterns/sidebar/Details.tsx
@@ -28,7 +28,7 @@ const Details: React.FC<{}> = () => {
                             <div
                                 style={{
                                     flex: 1,
-                                    overflow: 'scroll',
+                                    overflow: 'auto',
                                     padding: '16px',
                                 }}
                             >
@@ -53,7 +53,7 @@ const Details: React.FC<{}> = () => {
         flex: 1;
 
         /* Make it scrollable */
-        overflow: scroll;
+        overflow: auto;
     ">
         ...
     </main>


### PR DESCRIPTION
`overflow: auto` is usually a better choice than `overflow: scroll` when you want to make component scrollable. The only difference is that with `auto` you do not see the scrollbar when there's nothing to scroll.