### PR TITLE
Use HTML as common source across components

### DIFF
--- a/client/patterns/close-button/Cover.tsx
+++ b/client/patterns/close-button/Cover.tsx
@@ -7,6 +7,8 @@ import React from 'react';
 
 import Frame from '../../placeholders/Frame';
 
+import source from './source.html';
+
 const Cover: React.FC<{}> = () => {
     return (
         <Frame>
@@ -19,41 +21,8 @@ const Cover: React.FC<{}> = () => {
                     justifyContent: 'center',
                     padding: '8px',
                 }}
-            >
-                <button
-                    style={{
-                        backgroundColor: 'transparent',
-                        borderColor: 'transparent',
-                        cursor: 'pointer',
-                        height: '32px',
-                        position: 'relative',
-                        width: '32px',
-                    }}
-                >
-                    <div
-                        style={{
-                            backgroundColor: 'rgba(0, 0, 0, 0.3)',
-                            height: '1px',
-                            left: 0,
-                            position: 'absolute',
-                            top: '50%',
-                            transform: 'translate(0%, -50%) rotate(45deg)',
-                            width: '100%',
-                        }}
-                    />
-                    <div
-                        style={{
-                            backgroundColor: 'rgba(0, 0, 0, 0.3)',
-                            height: '100%',
-                            left: '50%',
-                            position: 'absolute',
-                            top: 0,
-                            transform: 'translate(-50%, 0%) rotate(45deg)',
-                            width: '1px',
-                        }}
-                    />
-                </button>
-            </div>
+                dangerouslySetInnerHTML={{__html: source}}
+            />
         </Frame>
     );
 };

--- a/client/patterns/close-button/Details.tsx
+++ b/client/patterns/close-button/Details.tsx
@@ -10,6 +10,7 @@ import RelatedPatterns from '../../components/RelatedPatterns';
 import Pattern from '../../constants/Pattern';
 import DetailsLayout from '../../layouts/DetailsLayout';
 import BrowserFrame from '../../placeholders/BrowserFrame';
+import source from './source.html';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -30,92 +31,12 @@ const Details: React.FC<{}> = () => {
                                 justifyContent: 'center',
                                 padding: '8px',
                             }}
-                        >
-                            <button
-                                style={{
-                                    backgroundColor: 'transparent',
-                                    borderColor: 'transparent',
-                                    cursor: 'pointer',
-                                    height: '32px',
-                                    position: 'relative',
-                                    width: '32px',
-                                }}
-                            >
-                                <div
-                                    style={{
-                                        backgroundColor: 'rgba(0, 0, 0, 0.3)',
-                                        height: '1px',
-                                        left: 0,
-                                        position: 'absolute',
-                                        top: '50%',
-                                        transform: 'translate(0%, -50%) rotate(45deg)',
-                                        width: '100%',
-                                    }}
-                                />
-                                <div
-                                    style={{
-                                        backgroundColor: 'rgba(0, 0, 0, 0.3)',
-                                        height: '100%',
-                                        left: '50%',
-                                        position: 'absolute',
-                                        top: 0,
-                                        transform: 'translate(-50%, 0%) rotate(45deg)',
-                                        width: '1px',
-                                    }}
-                                />
-                            </button>
-                        </div>
+                            dangerouslySetInnerHTML={{__html: source}}
+                        />
                     )}
-                    source={`
-<button style="
-    /* Reset */
-    background-color: transparent;
-    border-color: transparent;
-
-    /* Cursor */
-    cursor: pointer;
-
-    /* Size */
-    height: 32px;
-    width: 32px;
-
-    /* Used to position the inner */
-    position: relative;
-">
-    <div style="
-        /* Background color */
-        background-color: rgba(0, 0, 0, 0.3);
-
-        /* Position */
-        left: 0px;
-        position: absolute;
-        top: 50%;
-        transform: translate(0%, -50%) rotate(45deg);
-
-        /* Size */
-        height: 1px;
-        width: 100%;
-    " />
-
-    <div style="
-        /* Background color */
-        background-color: rgba(0, 0, 0, 0.3);
-
-        /* Position */
-        left: 50%;
-        position: absolute;
-        top: 0px;
-        transform: translate(-50%, 0%) rotate(45deg);
-
-        /* Size */
-        height: 100%;
-        width: 1px;
-    " />
-</button>
-`}
+                    source={source}
                 />
             </div>
-
             <RelatedPatterns patterns={[Pattern.ArrowButtons, Pattern.Chip, Pattern.Modal, Pattern.Notification]} />
         </DetailsLayout>
     );

--- a/client/patterns/close-button/source.html
+++ b/client/patterns/close-button/source.html
@@ -1,0 +1,45 @@
+<button style="
+    /* Reset */
+    background-color: transparent;
+    border-color: transparent;
+
+    /* Cursor */
+    cursor: pointer;
+
+    /* Size */
+    height: 32px;
+    width: 32px;
+
+    /* Used to position the inner */
+    position: relative;
+">
+    <div style="
+        /* Background color */
+        background-color: rgba(0, 0, 0, 0.3);
+
+        /* Position */
+        left: 0px;
+        position: absolute;
+        top: 50%;
+        transform: translate(0%, -50%) rotate(45deg);
+
+        /* Size */
+        height: 1px;
+        width: 100%;
+    "></div>
+
+    <div style="
+        /* Background color */
+        background-color: rgba(0, 0, 0, 0.3);
+
+        /* Position */
+        left: 50%;
+        position: absolute;
+        top: 0px;
+        transform: translate(-50%, 0%) rotate(45deg);
+
+        /* Size */
+        height: 100%;
+        width: 1px;
+    "></div>
+</button>

--- a/client/types/html.d.ts
+++ b/client/types/html.d.ts
@@ -1,0 +1,4 @@
+declare module '*.html' {
+    const value: string;
+    export default value
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8157,6 +8157,78 @@
                 "unpipe": "1.0.0"
             }
         },
+        "raw-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.1.tgz",
+            "integrity": "sha512-baolhQBSi3iNh1cglJjA0mYzga+wePk7vdEX//1dTFd+v4TsQlQE0jitJSNF1OIP82rdYulH7otaVmdlDaJ64A==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^2.6.5"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+                    "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "emojis-list": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+                    "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+                    "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+                    "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "2.6.6",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
+                    "integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.12.0",
+                        "ajv-keywords": "^3.4.1"
+                    }
+                }
+            }
+        },
         "react": {
             "version": "16.12.0",
             "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "html-webpack-plugin": "^3.2.0",
         "mini-css-extract-plugin": "^0.9.0",
         "postcss-loader": "^3.0.0",
+        "raw-loader": "^4.0.1",
         "react-snap": "^1.23.0",
         "rimraf": "^3.0.0",
         "source-map-loader": "^0.2.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,6 +75,10 @@ module.exports = {
                 use: ['babel-loader', 'ts-loader'],
             },
             {
+                test: /\.html$/i,
+                use: 'raw-loader',
+            },
+            {
                 enforce: "pre",
                 test: /\.js$/,
                 loader: 'source-map-loader',


### PR DESCRIPTION
Using webpack's `raw-loader`, HTML can be loaded as a string, then can be:
* passed to `BrowserFrame.source` for display and copying to the user's clipboard
* set as the `innerHTML` of the `<div>` passed to `BrowserFrame.content`
* set as the `innerHTML` of the `<div>` child of `Cover`

This would greatly reduce the duplication in the project's codebase, and therefore reduce the maintenance overhead going forward. It also means that the user sees exactly the result of the styled HTML they're about to copy, with no room for discrepancy between the source and the rendered component.

This PR configures all this for the whole project, and includes proof-of-concept work in `client/patterns/close-button`. If approved, this work could be applied to all pattern components.